### PR TITLE
feat(style): Update wallet-link to be consistent with font family

### DIFF
--- a/src/components/Drawer/drawer-content/drawer-content.scss
+++ b/src/components/Drawer/drawer-content/drawer-content.scss
@@ -16,6 +16,8 @@
       margin: 10px;
   
       p{
+        font-family: Montserrat SemiBold;
+        font-size: 14px;
         color: #FFFFFF;
       }
     }


### PR DESCRIPTION
Changed how the wallet-link class shows on Firefox
It goes from this:
<img width="298" alt="Captura de Pantalla 2021-11-20 a la(s) 1 42 58 p  m" src="https://user-images.githubusercontent.com/11529736/142734241-e2e5c147-352e-4a2c-b5f4-b2cf74d5c4f7.png">
to this:
<img width="351" alt="Captura de Pantalla 2021-11-20 a la(s) 1 40 50 p  m" src="https://user-images.githubusercontent.com/11529736/142734226-eace98f3-4ff1-4833-bda3-22cd31c19353.png">

