### PR TITLE
feat: add wMEMO balance & reward market value

### DIFF
--- a/src/Root/App.tsx
+++ b/src/Root/App.tsx
@@ -56,7 +56,7 @@ function App() {
 
     const loadApp = useCallback(
         loadProvider => {
-            dispatch(loadAppDetails({ networkID: chainID, provider: loadProvider }));
+            dispatch(loadAppDetails({ networkID: chainID, provider: loadProvider, address }));
             bonds.map(bond => {
                 dispatch(calcBondDetails({ bond, value: null, provider: loadProvider, networkID: chainID }));
             });

--- a/src/Root/Landing.tsx
+++ b/src/Root/Landing.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useCallback } from "react";
 import { useDispatch } from "react-redux";
-import { useWeb3Context } from "../hooks";
+import { useAddress, useWeb3Context } from "../hooks";
 import { loadAppDetails } from "../store/slices/app-slice";
 import Landing from "../views/Landing";
 import "./style.scss";
 
 function App() {
     const dispatch = useDispatch();
+    const address = useAddress();
 
     const { provider, chainID, connected } = useWeb3Context();
 
     const loadApp = useCallback(
         loadProvider => {
-            dispatch(loadAppDetails({ networkID: chainID, provider: loadProvider }));
+            dispatch(loadAppDetails({ networkID: chainID, provider: loadProvider, address }));
         },
         [connected],
     );

--- a/src/helpers/token-price.ts
+++ b/src/helpers/token-price.ts
@@ -13,3 +13,23 @@ export const loadTokenPrices = async () => {
 export const getTokenPrice = (symbol: string): number => {
     return Number(cache[symbol]);
 };
+
+export const getWMemoPrice = async (address: string): Promise<number> => {
+    // uses their public API key and passes in the connected wallet address to search for wMEMO.
+    // otherwise return 0
+    const url = `https://api.zapper.fi/v1/protocols/wonderland/balances?addresses[]=${address}&network=avalanche&api_key=5d1237c2-3840-4733-8e92-c5a58fe81b88&newBalances=true`;
+    const { data } = await axios.get(url);
+    const key = Object.keys(data)[0];
+
+    // no wMEMO or MEMO found, avoid errors.
+    if (data[key].products.length == 0) {
+        return 0;
+    }
+
+    // this may actually be MEMO not wMEMO... but the value will only
+    // get used and displayed if the wallet has a wMEMO balance...
+    // so we can assume it is wMEMO?!
+    const price = data[key].products[0].assets[0].tokens[0].price;
+
+    return price > 0 ? price : 0;
+};

--- a/src/store/slices/app-slice.ts
+++ b/src/store/slices/app-slice.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { getAddresses } from "../../constants";
 import { StakingContract, MemoTokenContract, TimeTokenContract } from "../../abi";
-import { setAll } from "../../helpers";
+import { getWMemoPrice, setAll } from "../../helpers";
 import { createSlice, createSelector, createAsyncThunk } from "@reduxjs/toolkit";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { getMarketPrice, getTokenPrice } from "../../helpers";
@@ -11,12 +11,13 @@ import allBonds from "../../helpers/bond";
 interface ILoadAppDetails {
     networkID: number;
     provider: JsonRpcProvider;
+    address: string;
 }
 
 export const loadAppDetails = createAsyncThunk(
     "app/loadAppDetails",
     //@ts-ignore
-    async ({ networkID, provider }: ILoadAppDetails) => {
+    async ({ networkID, provider, address }: ILoadAppDetails) => {
         const mimPrice = getTokenPrice("MIM");
         const addresses = getAddresses(networkID);
 
@@ -27,6 +28,7 @@ export const loadAppDetails = createAsyncThunk(
         const timeContract = new ethers.Contract(addresses.TIME_ADDRESS, TimeTokenContract, provider);
 
         const marketPrice = ((await getMarketPrice(networkID, provider)) / Math.pow(10, 9)) * mimPrice;
+        const wMemoMarketPrice = await getWMemoPrice(address);
 
         const totalSupply = (await timeContract.totalSupply()) / Math.pow(10, 9);
         const circSupply = (await memoContract.circulatingSupply()) / Math.pow(10, 9);
@@ -74,6 +76,7 @@ export const loadAppDetails = createAsyncThunk(
             stakingTVL,
             stakingRebase,
             marketPrice,
+            wMemoMarketPrice,
             currentBlockTime,
             nextRebase,
             rfv,
@@ -90,6 +93,7 @@ export interface IAppSlice {
     loading: boolean;
     stakingTVL: number;
     marketPrice: number;
+    wMemoMarketPrice: number;
     marketCap: number;
     circSupply: number;
     currentIndex: string;


### PR DESCRIPTION
Not an accomplished JS developer, ~couldn't figure out how to test these changes locally since the landing page links are hardcoded so even when running locally it points to prod, some documentation on how to fully set up locally and test the staking/dashboard views would be sweet 👌~

Just thought I'd try and contribute by adding some functionality I'd like to see personally.

**Staked with `wMEMO`:**
![image](https://user-images.githubusercontent.com/3999923/143374346-a7b1671d-7522-4e93-b7ca-5244f885124b.png)


**Staked with `MEMO`:**
![image](https://user-images.githubusercontent.com/3999923/143373967-a217497c-3240-41d2-84bb-154cf408403e.png)

